### PR TITLE
Develop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,6 @@ repos:
     hooks:
       - id: prettier
         types: [yaml]
+
+ci:
+  autoupdate_branch: "develop"

--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ a template for your own programs.
 - [x] Indicate current register in the UI
 - [x] Show execution errors in the UI
 - [ ] Flash register when it's value changes
-- [ ] Address-agnostic register insert/delete
-- [ ] Update starting address in the UI (propagates to all addresses)
+- [x] Register insert/delete
+- [ ] Auto-scroll to the current register
+- [ ] Register re-addressing (when moving registers around)
+- [ ] Update starting address (propagates to all addresses)
 - [ ] Improve editor UX
     - [ ] Add syntax highlighting for operations
     - [ ] Add autocomplete for `#` labels

--- a/components.d.ts
+++ b/components.d.ts
@@ -12,6 +12,7 @@ declare module 'vue' {
     Card: typeof import('primevue/card')['default']
     Column: typeof import('primevue/column')['default']
     ConfirmPopup: typeof import('primevue/confirmpopup')['default']
+    ContextMenu: typeof import('primevue/contextmenu')['default']
     DataRegisters: typeof import('./src/components/emulator/DataRegisters.vue')['default']
     DataTable: typeof import('primevue/datatable')['default']
     DownloadButton: typeof import('./src/components/DownloadButton.vue')['default']

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -10,9 +10,9 @@ const globalState: GlobalState = inject('globalState') || {} as GlobalState;
 <template>
   <div id="editor">
     <OperationsTable />
-    <RegisterTable :editable="true" :title="'Registros Auxiliares'" :registers="globalState.program.aux_registers" />
-    <RegisterTable :editable="true" :title="'Program'" :registers="globalState.program.registers" />
-    <RegisterTable :editable="true" :title="'Data'" :registers="globalState.program.data_registers" />
+    <RegisterTable editable :title="'Registros Auxiliares'" :registers="globalState.program.aux_registers" />
+    <RegisterTable editable :title="'Program'" :registers="globalState.program.registers" />
+    <RegisterTable editable :title="'Data'" :registers="globalState.program.data_registers" />
   </div>
 </template>
 

--- a/src/components/RegisterTable.vue
+++ b/src/components/RegisterTable.vue
@@ -28,14 +28,23 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { PropType, ref } from 'vue';
 import { Register } from './../abacus/program';
 
-const props = defineProps<{
-    title: string
-    registers: Register[],
-    editable: boolean
-}>()
+const props = defineProps({
+    title: String,
+    registers: {
+        type: Array as PropType<Register[]>,
+        required: true
+    },
+    editable: {
+        type: Boolean,
+        required: false,
+        default(_: any) {
+            return false;
+        }
+    }
+})
 
 const editMode = props.editable ? 'cell' : undefined
 

--- a/src/components/emulator/AuxRegisters.vue
+++ b/src/components/emulator/AuxRegisters.vue
@@ -16,7 +16,7 @@ const registers = computed(
 </script>
 
 <template>
-    <RegisterTable :editable="false" :title="'Registros Auxiliares'" :registers="registers" />
+    <RegisterTable :title="'Registros Auxiliares'" :registers="registers" />
 </template>
 
 <style scoped>

--- a/src/components/emulator/DataRegisters.vue
+++ b/src/components/emulator/DataRegisters.vue
@@ -17,7 +17,7 @@ const registers = computed(() => {
 </script>
 
 <template>
-    <RegisterTable :editable="false" :title="'Data'" :registers="registers" />
+    <RegisterTable :title="'Data'" :registers="registers" />
 </template>
 
 <style scoped>


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and user experience of the register tables in the project. The most important changes include adding context menu support for register tables, updating the `README.md` to reflect the current state of the project, and modifying the `.pre-commit-config.yaml` file to include a new CI configuration.

Enhancements to register tables:

* [`src/components/RegisterTable.vue`](diffhunk://#diff-558b9a73ca4ae727c99403c5c8d645bc522b26f632f1d0a04d535c003cf6a7d4L1-R8): Added context menu support for register tables, including options to insert above, insert below, and delete registers. This involved significant changes to the script setup, including defining props, setting up the context menu, and handling context menu actions. [[1]](diffhunk://#diff-558b9a73ca4ae727c99403c5c8d645bc522b26f632f1d0a04d535c003cf6a7d4L1-R8) [[2]](diffhunk://#diff-558b9a73ca4ae727c99403c5c8d645bc522b26f632f1d0a04d535c003cf6a7d4R29-R85)
* [`src/components/Editor.vue`](diffhunk://#diff-9a196164961cc525c2362569d39ae48b643c944dc108fc5843cd52c31600074eL13-R15): Simplified the `RegisterTable` component usage by removing unnecessary `editable` attribute bindings.
* `src/components/emulator/AuxRegisters.vue` and `src/components/emulator/DataRegisters.vue`: Removed the `editable` attribute from `RegisterTable` components as it is now handled internally. [[1]](diffhunk://#diff-d8a1a925499ff7edead50d3fbe0aa1868ea20bce6d6d8606166057dfb53d90b3L19-R19) [[2]](diffhunk://#diff-9c02956793a14512021060b471a80f1a1bf3796c00a5341af41565943a6b4621L20-R20)

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R73): Updated the project task list to reflect the current state of the project, including marking the register insert/delete task as completed and adding new tasks for auto-scrolling and register re-addressing.

Configuration changes:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R38-R40): Added a new CI configuration to auto-update the branch to "develop" during pre-commit checks.